### PR TITLE
fix error with pyserial and ignore some errors

### DIFF
--- a/bcm_cfedump.py
+++ b/bcm_cfedump.py
@@ -245,6 +245,22 @@ class CFEParserBase:
             if line.startswith(b"-----"):
                 break
 
+            # ignore Uncorrectable errors
+            if line.startswith(b"Uncorrectable ECC Error"):
+                continue
+
+            # ignore more errors
+            if line.startswith(b"nand_flash_read_buf(): Att"):
+                continue
+
+            if line.startswith(b"Error reading block"):
+                continue
+
+            #danitool begin: eat crashing line
+            if line.startswith(b"Correctable ECC Error detected"):
+                continue
+            #danitool end
+
             if len(line) == 0:
                 continue
 

--- a/bcm_cfedump.py
+++ b/bcm_cfedump.py
@@ -311,6 +311,9 @@ class CFECommunicator(CFEParserBase):
         self.ser = serial
 
     def _read(self, *a, **kw) -> bytes:
+        if not type(*a) is int:
+            self.ser.write(*a, **kw)
+            return self.ser.read(len(*a))
         return self.ser.read(*a, **kw)
 
     def _write(self, *a, **kw) -> int:

--- a/bcm_cfedump.py
+++ b/bcm_cfedump.py
@@ -249,7 +249,8 @@ class CFEParserBase:
                 continue
 
             try:
-                addr, buf = parse_serial_line(line.decode())
+                addr, buf_temp = parse_serial_line(line.decode())
+                buf += buf_temp
             except UnicodeDecodeError:
                 traceback.print_exc()
 


### PR DESCRIPTION
1. allow write command to serial console with read() function then doing a read. 
2. fix read_page size (16) always different then expect (2048)
3. ignore some read errors to prevent some parsing errors.

tested in Ubuntu 16.04.7 (Python 3.6 + pySerial v3.4) with cmd: 
```
$ python3 bcm_cfedump.py -D /dev/ttyUSB0 -O nand.bin -t 0.01 nand
```
I did not test the nand_bulk command.