### PR TITLE
fixed ZeroDivisionError bug

### DIFF
--- a/bcm_cfedump.py
+++ b/bcm_cfedump.py
@@ -152,7 +152,10 @@ class ProgressPrinter(PrettyPrinter):
             string += "[{}/s] ".format(format_size(speed))
 
             remaining = total - done
-            eta = int(remaining // speed)
+            try:
+                eta = int(remaining // speed)
+            except ZeroDivisionError:
+                eta = int(0)
 
             string += "[ETA: {}]".format(format_time(eta))
 


### PR DESCRIPTION
1.5 days into a 512MB NAND dump and the program decided to divide by zero, which crashed the program...hopefully this fixes anyone losing their sanity in the future.